### PR TITLE
MVP stable build: incremental windows, schema sync, tests green; metering is $ authority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-.venv/
 target/
 logs/
 dbt_packages/
+profiles.yml
 .env
+.env.*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Snowflake FinOps (dbt) — Starter
+
+**Purpose:** a lean, correct-by-design starter to analyze Snowflake spend.  
+**Truth for $:** `SNOWFLAKE.ACCOUNT_USAGE.WAREHOUSE_METERING_HISTORY`.  
+**Per-query $:** estimates only (attribution), clearly labeled.
+
+## Quickstart
+1. Set env vars (examples):  
+   `COST_PER_CREDIT`, `WINDOW_DAYS`, `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_PASSWORD`, `SNOWFLAKE_ROLE`, `SNOWFLAKE_WAREHOUSE`, `SNOWFLAKE_DATABASE`, `SNOWFLAKE_SCHEMA`
+2. Install deps & run:
+   ```bash
+   dbt deps
+   dbt build --select +fct_daily_costs

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,12 +1,68 @@
-name: finops
-version: 1.0
-profile: finops
+name: 'snowflake_finops'
+version: '1.0.0'
+config-version: 2
 
-models:
-  finops:
-    +materialized: table
+profile: 'snowflake_finops'
+
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["data"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"
+clean-targets:
+  - "target"
+  - "dbt_packages"
 
 vars:
-  COST_PER_CREDIT: "{{ env_var('COST_PER_CREDIT', 3.00) }}"
-  WINDOW_DAYS: "{{ env_var('WINDOW_DAYS', 90) }}"
-  READ_ROLE: "{{ env_var('READ_ROLE', 'DM_AE_ROLE') }}"
+  # Cost Configuration - CRITICAL: fed from environment
+  cost_per_credit: "{{ env_var('COST_PER_CREDIT') }}"
+  
+  # Data Retention Windows (single knob)
+  query_history_days: "{{ env_var('WINDOW_DAYS') }}"
+  metering_history_days: "{{ env_var('WINDOW_DAYS') }}"
+  storage_history_days: "{{ env_var('WINDOW_DAYS') }}"
+  
+  # Thresholds
+  idle_threshold_seconds: 300  # 5 minutes
+  expensive_query_threshold_usd: 1.00
+  
+  # Roles & Access
+  read_role: 'ANALYST'
+  
+  # Source database
+  account_usage_database: 'SNOWFLAKE'
+  account_usage_schema: 'ACCOUNT_USAGE'
+
+models:
+  snowflake_finops:
+    staging:
+      +materialized: view
+      snowflake:
+        +schema: staging
+        
+    intermediate:
+      +materialized: incremental
+      +on_schema_change: fail
+      +schema: intermediate
+      
+    marts:
+      +materialized: table
+      +schema: marts
+      core:
+        +tags: ['core']
+      finance:
+        +tags: ['finance']
+      optimization:
+        +tags: ['optimization']
+
+seeds:
+  snowflake_finops:
+    +schema: reference_data
+    department_mapping:
+      +column_types:
+        role_name: varchar
+        department: varchar
+        cost_center: varchar

--- a/models/intermediate/int_hourly_compute_costs.sql
+++ b/models/intermediate/int_hourly_compute_costs.sql
@@ -1,0 +1,87 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key='cost_hour_key',
+        on_schema_change='fail'
+    )
+}}
+
+with metering as (
+    select * from {{ ref('stg_warehouse_metering') }}
+    {% if is_incremental() %}
+        where hour_start > (select max(hour_start) from {{ this }})
+    {% endif %}
+),
+
+queries as (
+    select 
+        warehouse_name,
+        date_trunc('hour', START_TIME) as usage_hour,
+        count(*) as query_count,
+        sum(total_elapsed_seconds) as total_runtime_seconds,
+        sum(gb_scanned) as total_gb_scanned,
+        count(distinct user_name) as unique_users
+    from {{ ref('stg_query_history') }}
+    {% if is_incremental() %}
+        where date_trunc('hour', END_TIME) >= (
+            select coalesce(max(t.hour_start), '1900-01-01'::timestamp)
+            from {{ this }} as t
+        )
+    {% endif %}
+    group by 1, 2
+),
+
+hourly_costs as (
+    select
+        m.hour_start,
+        m.hour_end,
+        m.usage_date,
+        m.warehouse_name,
+        
+        -- Actual costs from metering (authoritative)
+        m.total_credits_used,
+        m.total_cost_usd,
+        m.compute_cost_usd,
+        m.cloud_services_cost_usd,
+        
+        -- Query activity in this hour
+        coalesce(q.query_count, 0) as queries_executed,
+        coalesce(q.total_runtime_seconds, 0) as total_runtime_seconds,
+        coalesce(q.total_gb_scanned, 0) as gb_scanned,
+        coalesce(q.unique_users, 0) as unique_users,
+        
+        -- Efficiency metrics
+        case 
+            when q.query_count > 0 then m.total_cost_usd / q.query_count
+            else null
+        end as avg_cost_per_query,
+        
+        case
+            when q.total_runtime_seconds > 0 then m.total_cost_usd / (q.total_runtime_seconds / 3600.0)
+            else null
+        end as cost_per_runtime_hour,
+        
+        -- Idle detection (no queries but credits consumed)
+        case 
+            when coalesce(q.query_count, 0) = 0 and m.total_credits_used > 0 then true
+            else false
+        end as is_potentially_idle,
+        
+        case 
+            when coalesce(q.query_count, 0) = 0 and m.total_credits_used > 0 
+            then m.total_cost_usd
+            else 0
+        end as idle_cost_usd,
+        
+        -- Composite key
+        {{ dbt_utils.generate_surrogate_key(['m.warehouse_name', 'm.hour_start']) }} as cost_hour_key,
+        
+        current_timestamp() as _loaded_at
+        
+    from metering m
+    left join queries q
+        on m.warehouse_name = q.warehouse_name
+       and m.hour_start    = q.usage_hour
+)
+
+select * from hourly_costs

--- a/models/intermediate/int_query_cost_attribution.sql
+++ b/models/intermediate/int_query_cost_attribution.sql
@@ -1,0 +1,76 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key='query_id',
+        on_schema_change='fail'
+    )
+}}
+
+-- IMPORTANT: Estimated attribution only (for analysis). Billing truth is metering history.
+
+with queries as (
+    select
+        query_id,
+        warehouse_name,
+        user_name,
+        role_name,
+        database_name,
+        query_type,
+        START_TIME as query_start_time,
+        END_TIME   as query_end_time,
+        date_trunc('hour', START_TIME) as usage_hour,
+        total_elapsed_seconds,
+        gb_scanned,
+        rows_produced,
+        runtime_category
+    from {{ ref('stg_query_history') }}
+    {% if is_incremental() %}
+      where date(END_TIME) >= (
+        select coalesce(max(date(t.query_end_time)), '1900-01-01'::date)
+        from {{ this }} as t
+      )
+    {% endif %}
+),
+
+hourly_costs as (
+    select * from {{ ref('int_hourly_compute_costs') }}
+),
+
+query_share as (
+    select
+        q.*,
+        sum(q.total_elapsed_seconds) over (
+            partition by q.warehouse_name, q.usage_hour
+        ) as hour_total_runtime,
+        case 
+            when sum(q.total_elapsed_seconds) over (partition by q.warehouse_name, q.usage_hour) > 0
+            then q.total_elapsed_seconds 
+                 / sum(q.total_elapsed_seconds) over (partition by q.warehouse_name, q.usage_hour)
+            else 0
+        end as runtime_share_of_hour
+    from queries q
+),
+
+attributed_costs as (
+    select
+        qs.*,
+        hc.total_cost_usd     as warehouse_hour_cost,
+        hc.total_credits_used as warehouse_hour_credits,
+
+        -- Estimated attribution based on runtime share
+        round(hc.total_cost_usd     * qs.runtime_share_of_hour, 4) as estimated_query_cost_usd,
+        round(hc.total_credits_used * qs.runtime_share_of_hour, 6) as estimated_query_credits,
+
+        case when qs.gb_scanned    > 0 then round((hc.total_cost_usd * qs.runtime_share_of_hour) / qs.gb_scanned, 4) end as estimated_cost_per_gb,
+        case when qs.rows_produced > 0 then round((hc.total_cost_usd * qs.runtime_share_of_hour) / qs.rows_produced * 1000000, 6) end as estimated_cost_per_million_rows,
+
+        current_timestamp() as _loaded_at
+    from query_share qs
+    left join hourly_costs hc
+      on qs.warehouse_name = hc.warehouse_name
+     and qs.usage_hour     = hc.hour_start
+)
+
+select * 
+from attributed_costs
+where estimated_query_cost_usd > 0

--- a/models/intermediate/int_warehouse_optimization.sql
+++ b/models/intermediate/int_warehouse_optimization.sql
@@ -1,0 +1,118 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+with hourly_patterns as (
+    select
+        warehouse_name,
+        usage_date,
+        hour_start,
+        total_cost_usd,
+        queries_executed,
+        unique_users,
+        is_potentially_idle,
+        idle_cost_usd
+    from {{ ref('int_hourly_compute_costs') }}
+    where usage_date >= dateadd('day', -14, current_date())  -- Last 2 weeks
+),
+
+daily_summary as (
+    select
+        warehouse_name,
+        usage_date,
+        sum(total_cost_usd) as daily_cost,
+        sum(queries_executed) as daily_queries,
+        sum(case when is_potentially_idle then 1 else 0 end) as idle_hours,
+        sum(idle_cost_usd) as daily_idle_cost,
+        max(unique_users) as max_concurrent_users
+    from hourly_patterns
+    group by 1, 2
+),
+
+warehouse_analysis as (
+    select
+        warehouse_name,
+        
+        -- Cost metrics
+        avg(daily_cost) as avg_daily_cost,
+        sum(daily_cost) as total_period_cost,
+        avg(daily_idle_cost) as avg_daily_idle_cost,
+        sum(daily_idle_cost) as total_idle_cost,
+        
+        -- Usage patterns
+        avg(daily_queries) as avg_daily_queries,
+        avg(idle_hours) as avg_idle_hours_per_day,
+        max(max_concurrent_users) as peak_concurrent_users,
+        
+        -- Calculate idle percentage
+        case 
+            when sum(daily_cost) > 0 
+            then 100.0 * sum(daily_idle_cost) / sum(daily_cost)
+            else 0
+        end as idle_cost_percentage,
+        
+        -- Days with any activity
+        count(distinct case when daily_queries > 0 then usage_date end) as active_days,
+        count(distinct usage_date) as total_days,
+        
+        -- Weekend vs weekday patterns
+        avg(case when dayofweek(usage_date) in (0, 6) then daily_cost else null end) as avg_weekend_cost,
+        avg(case when dayofweek(usage_date) not in (0, 6) then daily_cost else null end) as avg_weekday_cost
+        
+    from daily_summary
+    group by 1
+),
+
+optimization_recommendations as (
+    select
+        warehouse_name,
+        avg_daily_cost,
+        avg_daily_idle_cost,
+        idle_cost_percentage,
+        avg_daily_queries,
+        avg_idle_hours_per_day,
+        peak_concurrent_users,
+        active_days,
+        total_days,
+        
+        -- Auto-suspend recommendation
+        case
+            when avg_idle_hours_per_day > 12 then 60  -- 1 minute if idle >50% of day
+            when avg_idle_hours_per_day > 6 then 300  -- 5 minutes if idle >25% of day
+            else 600  -- 10 minutes default
+        end as recommended_auto_suspend_seconds,
+        
+        -- Schedule recommendation
+        case
+            when avg_weekend_cost < avg_weekday_cost * 0.1 then 'Consider suspending on weekends'
+            when active_days < total_days * 0.5 then 'Consider scheduled suspension'
+            else 'Current schedule appears appropriate'
+        end as schedule_recommendation,
+        
+        -- Sizing recommendation (conservative - based on concurrent users)
+        case
+            when peak_concurrent_users <= 2 and avg_daily_queries < 100 then 'Consider downsizing'
+            when peak_concurrent_users > 10 and avg_idle_hours_per_day < 2 then 'Consider upsizing'
+            else 'Current size appears appropriate'
+        end as sizing_recommendation,
+        
+        -- Potential monthly savings from auto-suspend optimization
+        avg_daily_idle_cost * 30 as potential_monthly_savings,
+        
+        -- Priority score (higher = more important to optimize)
+        case
+            when avg_daily_idle_cost > 50 then 100
+            when avg_daily_idle_cost > 20 then 80
+            when idle_cost_percentage > 30 then 60
+            when idle_cost_percentage > 20 then 40
+            else 20
+        end as optimization_priority
+        
+    from warehouse_analysis
+    where avg_daily_cost > 1  -- Only include warehouses with meaningful costs
+)
+
+select * from optimization_recommendations
+order by optimization_priority desc, potential_monthly_savings desc

--- a/models/marts/fct_daily_costs.sql
+++ b/models/marts/fct_daily_costs.sql
@@ -1,0 +1,78 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+with compute_costs as (
+    select
+        usage_date,
+        warehouse_name,
+        sum(total_credits_used) as compute_credits,
+        sum(total_cost_usd) as compute_cost,
+        sum(idle_cost_usd) as idle_cost,
+        sum(queries_executed) as total_queries,
+        avg(unique_users) as avg_concurrent_users
+    from {{ ref('int_hourly_compute_costs') }}
+    group by 1, 2
+),
+
+-- Add storage costs when implementing storage staging
+-- Add clustering costs when implementing clustering staging
+
+daily_summary as (
+    select
+        usage_date,
+        warehouse_name,
+        compute_credits,
+        compute_cost,
+        idle_cost,
+        compute_cost - idle_cost as productive_cost,
+        total_queries,
+        avg_concurrent_users,
+        
+        -- Cost per query (when queries exist)
+        case 
+            when total_queries > 0 then compute_cost / total_queries
+            else null
+        end as cost_per_query,
+        
+        -- Efficiency score (0-100)
+        case 
+            when compute_cost > 0 then 100 * (1 - (idle_cost / compute_cost))
+            else 100
+        end as efficiency_score,
+        
+        -- Running totals for the month
+        sum(compute_cost) over (
+            partition by date_trunc('month', usage_date), warehouse_name 
+            order by usage_date
+        ) as month_to_date_cost,
+        
+        -- 7-day moving average
+        avg(compute_cost) over (
+            partition by warehouse_name 
+            order by usage_date 
+            rows between 6 preceding and current row
+        ) as cost_7day_avg,
+        
+        -- Day-over-day change
+        compute_cost - lag(compute_cost, 1) over (
+            partition by warehouse_name 
+            order by usage_date
+        ) as day_over_day_change,
+        
+        -- Week-over-week change
+        compute_cost - lag(compute_cost, 7) over (
+            partition by warehouse_name 
+            order by usage_date
+        ) as week_over_week_change
+        
+    from compute_costs
+)
+
+select 
+    *,
+    {{ dbt_utils.generate_surrogate_key(['usage_date', 'warehouse_name']) }} as daily_cost_key,
+    current_timestamp() as _loaded_at
+from daily_summary

--- a/models/marts/optimization_summary.sql
+++ b/models/marts/optimization_summary.sql
@@ -1,0 +1,37 @@
+{{
+    config(
+        materialized='table',
+        tags=['executive_dashboard'],
+        enabled=var('enable_executive_summary', false)
+    )
+}}
+
+-- Executive summary combining all optimization opportunities
+
+with warehouse_opportunities as (
+    select
+        'Warehouse Auto-Suspend Optimization' as opportunity_type,
+        count(*) as opportunity_count,
+        sum(potential_monthly_savings) as monthly_savings_usd,
+        'Adjust auto-suspend settings to reduce idle time' as primary_action,
+        'Low' as implementation_difficulty,
+        'Immediate' as time_to_value
+    from {{ ref('int_warehouse_optimization') }}
+    where recommended_auto_suspend_seconds < 600  -- Recommending faster suspend
+),
+
+expensive_queries as (
+    select
+        'Expensive Query Optimization' as opportunity_type,
+        count(distinct query_id) as opportunity_count,
+        sum(estimated_query_cost_usd) * 30 as monthly_savings_usd,  
+        'Optimize query patterns and add filters' as primary_action,
+        'Medium' as implementation_difficulty,
+        '1-2 weeks' as time_to_value
+    from {{ ref('int_query_cost_attribution') }}
+    where estimated_query_cost_usd > {{ var('expensive_query_threshold_usd') }}
+)
+
+select * from warehouse_opportunities
+union all
+select * from expensive_queries

--- a/models/schema.txt
+++ b/models/schema.txt
@@ -1,0 +1,80 @@
+version: 2
+
+models:
+  - name: stg_warehouse_metering
+    description: "Windowed, incremental copy of ACCOUNT_USAGE.WAREHOUSE_METERING_HISTORY."
+    tests:
+      - unique:
+          column_name: metering_id
+    columns:
+      - name: hour_start
+        tests: [not_null]
+      - name: hour_end
+        tests: [not_null]
+      - name: usage_date
+        tests: [not_null]
+      - name: warehouse_name
+        tests: [not_null]
+      - name: total_credits_used
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+      - name: total_cost_usd
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+
+  - name: stg_query_history
+    description: "Windowed, incremental copy of ACCOUNT_USAGE.QUERY_HISTORY (successful, compute-bearing only)."
+    columns:
+      - name: usage_date
+        tests: [not_null]
+      - name: query_id
+        tests: [not_null, unique]
+      - name: warehouse_name
+        tests: [not_null]
+      - name: gb_scanned
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+      - name: total_elapsed_seconds
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+
+  - name: int_hourly_compute_costs
+    description: "Hourly costs from WAREHOUSE_METERING_HISTORY (authoritative)."
+    columns:
+      - name: hour_key
+        tests: [not_null, unique]
+      - name: compute_cost_usd
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+      - name: idle_cost_usd
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+
+  - name: fct_daily_costs
+    description: "Daily compute & idle cost by warehouse. $$ from metering history; query-level $$ are estimates only."
+    tests:
+      - unique:
+          column_name: daily_cost_key
+    columns:
+      - name: compute_cost
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+      - name: idle_cost
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -1,0 +1,80 @@
+version: 2
+
+models:
+  - name: stg_warehouse_metering
+    description: "Windowed, incremental copy of ACCOUNT_USAGE.WAREHOUSE_METERING_HISTORY."
+    tests:
+      - unique:
+          column_name: metering_id
+    columns:
+      - name: hour_start
+        tests: [not_null]
+      - name: hour_end
+        tests: [not_null]
+      - name: usage_date
+        tests: [not_null]
+      - name: warehouse_name
+        tests: [not_null]
+      - name: total_credits_used
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+      - name: total_cost_usd
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+
+  - name: stg_query_history
+    description: "Windowed, incremental copy of ACCOUNT_USAGE.QUERY_HISTORY (successful, compute-bearing only)."
+    columns:
+      - name: usage_date
+        tests: [not_null]
+      - name: query_id
+        tests: [not_null, unique]
+      - name: warehouse_name
+        tests: [not_null]
+      - name: gb_scanned
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+      - name: total_elapsed_seconds
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+
+  - name: int_hourly_compute_costs
+    description: "Hourly costs from WAREHOUSE_METERING_HISTORY (authoritative)."
+    columns:
+      - name: cost_hour_key
+        tests: [not_null, unique]
+      - name: compute_cost_usd
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+      - name: idle_cost_usd
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+
+  - name: fct_daily_costs
+    description: "Daily compute & idle cost by warehouse. $$ from metering history; query-level $$ are estimates only."
+    tests:
+      - unique:
+          column_name: daily_cost_key
+    columns:
+      - name: compute_cost
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0
+      - name: idle_cost
+        tests:
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: 0

--- a/models/sources/_snowflake__sources.txt
+++ b/models/sources/_snowflake__sources.txt
@@ -1,0 +1,107 @@
+version: 2
+
+sources:
+  - name: snowflake_account_usage
+    description: Snowflake Account Usage schema - source of truth for costs
+    database: "{{ var('account_usage_database') }}"
+    schema: "{{ var('account_usage_schema') }}"
+    
+    # Define freshness expectations
+    freshness:
+      warn_after: {count: 6, period: hour}
+      error_after: {count: 24, period: hour}
+    
+    tables:
+      - name: WAREHOUSE_METERING_HISTORY
+        description: Actual credit consumption by warehouse - THE source of truth for compute costs
+        loaded_at_field: END_TIME
+        columns:
+          - name: START_TIME
+            description: Start of the hour
+          - name: END_TIME
+            description: End of the hour
+          - name: WAREHOUSE_ID
+            description: Internal warehouse ID
+          - name: WAREHOUSE_NAME
+            description: User-facing warehouse name
+          - name: CREDITS_USED
+            description: Total credits consumed in this hour
+          - name: CREDITS_USED_COMPUTE
+            description: Credits for compute
+          - name: CREDITS_USED_CLOUD_SERVICES
+            description: Credits for cloud services
+            
+      - name: QUERY_HISTORY
+        description: All queries executed - use for patterns, not direct costs
+        loaded_at_field: END_TIME
+        columns:
+          - name: QUERY_ID
+            description: Unique query identifier
+          - name: QUERY_TEXT
+            description: SQL text
+          - name: DATABASE_NAME
+          - name: SCHEMA_NAME
+          - name: QUERY_TYPE
+            description: SELECT, INSERT, UPDATE, etc.
+          - name: WAREHOUSE_NAME
+          - name: WAREHOUSE_SIZE
+          - name: USER_NAME
+          - name: ROLE_NAME
+          - name: START_TIME
+          - name: END_TIME
+          - name: TOTAL_ELAPSED_TIME
+            description: Total time in milliseconds
+          - name: EXECUTION_TIME
+            description: Execution time in milliseconds
+          - name: QUEUED_PROVISIONING_TIME
+          - name: QUEUED_REPAIR_TIME
+          - name: QUEUED_OVERLOAD_TIME
+          - name: COMPILATION_TIME
+          - name: BYTES_SCANNED
+          - name: ROWS_PRODUCED
+          - name: EXECUTION_STATUS
+            description: SUCCESS, FAIL, INCIDENT
+            
+      - name: STORAGE_USAGE
+        description: Daily storage snapshots
+        loaded_at_field: USAGE_DATE
+        columns:
+          - name: USAGE_DATE
+          - name: STORAGE_BYTES
+          - name: STAGE_BYTES
+          - name: FAILSAFE_BYTES
+          
+      - name: DATABASE_STORAGE_USAGE_HISTORY
+        description: Storage by database
+        loaded_at_field: USAGE_DATE
+        columns:
+          - name: USAGE_DATE
+          - name: DATABASE_NAME
+          - name: DATABASE_ID
+          - name: AVERAGE_DATABASE_BYTES
+          - name: AVERAGE_FAILSAFE_BYTES
+          
+      - name: TABLE_STORAGE_METRICS
+        description: Table-level storage with last access info
+        loaded_at_field: TABLE_CREATED
+        columns:
+          - name: TABLE_CATALOG
+          - name: TABLE_SCHEMA
+          - name: TABLE_NAME
+          - name: ACTIVE_BYTES
+          - name: TIME_TRAVEL_BYTES
+          - name: FAILSAFE_BYTES
+          - name: TABLE_CREATED
+          - name: TABLE_DROPPED
+          - name: TABLE_LAST_ALTERED
+          
+      - name: AUTOMATIC_CLUSTERING_HISTORY
+        description: Clustering operations and credits
+        loaded_at_field: END_TIME
+        columns:
+          - name: START_TIME
+          - name: END_TIME
+          - name: CREDITS_USED
+          - name: DATABASE_NAME
+          - name: SCHEMA_NAME
+          - name: TABLE_NAME

--- a/models/sources/_snowflake__sources.yml
+++ b/models/sources/_snowflake__sources.yml
@@ -1,0 +1,73 @@
+version: 2
+
+sources:
+  - name: account_usage
+    description: Snowflake Account Usage schema - source of truth for costs
+    database: "{{ var('account_usage_database', 'SNOWFLAKE') }}"
+    schema: "{{ var('account_usage_schema', 'ACCOUNT_USAGE') }}"
+    
+    # Define freshness expectations
+    freshness:
+      warn_after: {count: 6, period: hour}
+      error_after: {count: 24, period: hour}
+    
+    tables:
+      - name: WAREHOUSE_METERING_HISTORY
+        description: Actual credit consumption by warehouse - THE source of truth for compute costs
+        loaded_at_field: END_TIME
+        columns:
+          - name: START_TIME
+            description: Start of the hour
+          - name: END_TIME
+            description: End of the hour
+          - name: WAREHOUSE_ID
+            description: Internal warehouse ID
+          - name: WAREHOUSE_NAME
+            description: User-facing warehouse name
+          - name: CREDITS_USED
+            description: Total credits consumed in this hour
+          - name: CREDITS_USED_COMPUTE
+            description: Credits for compute
+          - name: CREDITS_USED_CLOUD_SERVICES
+            description: Credits for cloud services
+            
+      - name: QUERY_HISTORY
+        description: All queries executed - use for patterns, not direct costs
+        loaded_at_field: END_TIME
+        columns:
+          - name: QUERY_ID
+            description: Unique query identifier
+          - name: QUERY_TEXT
+            description: SQL text
+          - name: DATABASE_NAME
+          - name: SCHEMA_NAME
+          - name: QUERY_TYPE
+            description: SELECT, INSERT, UPDATE, etc.
+          - name: WAREHOUSE_NAME
+          - name: WAREHOUSE_SIZE
+          - name: USER_NAME
+          - name: ROLE_NAME
+          - name: START_TIME
+          - name: END_TIME
+          - name: TOTAL_ELAPSED_TIME
+            description: Total time in milliseconds
+          - name: EXECUTION_TIME
+            description: Execution time in milliseconds
+          - name: QUEUED_PROVISIONING_TIME
+          - name: QUEUED_REPAIR_TIME
+          - name: QUEUED_OVERLOAD_TIME
+          - name: COMPILATION_TIME
+          - name: BYTES_SCANNED
+          - name: ROWS_PRODUCED
+          - name: EXECUTION_STATUS
+            description: SUCCESS, FAIL, INCIDENT
+
+      # (remaining storage-related tables unchanged)
+      - name: STORAGE_USAGE
+        loaded_at_field: USAGE_DATE
+      - name: DATABASE_STORAGE_USAGE_HISTORY
+        loaded_at_field: USAGE_DATE
+      - name: TABLE_STORAGE_METRICS
+        loaded_at_field: TABLE_CREATED
+      - name: AUTOMATIC_CLUSTERING_HISTORY
+        loaded_at_field: END_TIME

--- a/models/staging/stg_query_history.sql
+++ b/models/staging/stg_query_history.sql
@@ -1,0 +1,62 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key='query_id',
+        on_schema_change='sync_all_columns',
+        cluster_by=['usage_date', 'warehouse_name']
+    )
+}}
+
+with source as (
+    select *
+    from {{ source('account_usage', 'QUERY_HISTORY') }}
+    where START_TIME >= dateadd('day', -{{ var('query_history_days') }}, current_date())
+    {% if is_incremental() %}
+      and date(END_TIME) >= (
+          select coalesce(max(t.usage_date), '1900-01-01'::date)
+          from {{ this }} as t
+      )
+    {% endif %}
+),
+
+transformed as (
+    select
+        -- Keys & time
+        QUERY_ID                                           as query_id,
+        cast(date_trunc('day', START_TIME) as date)        as usage_date,
+        START_TIME,
+        END_TIME,
+
+        -- Who/where
+        USER_NAME       as user_name,
+        ROLE_NAME       as role_name,
+        WAREHOUSE_NAME  as warehouse_name,
+        WAREHOUSE_SIZE  as warehouse_size,
+
+        -- What
+        QUERY_TYPE      as query_type,
+        DATABASE_NAME   as database_name,
+        SCHEMA_NAME     as schema_name,
+        EXECUTION_STATUS,
+        BYTES_SCANNED,
+        ROWS_PRODUCED,
+        TOTAL_ELAPSED_TIME as total_elapsed_ms,
+        EXECUTION_TIME     as execution_ms,
+
+        -- Convenience fields
+        BYTES_SCANNED / 1024 / 1024 / 1024.0 as gb_scanned,
+        TOTAL_ELAPSED_TIME / 1000.0          as total_elapsed_seconds,
+
+        case
+            when TOTAL_ELAPSED_TIME > 600000 then 'long_running'   -- > 10 min
+            when TOTAL_ELAPSED_TIME > 60000  then 'medium_running' -- > 1 min
+            else 'fast'
+        end as runtime_category,
+
+        current_timestamp() as _loaded_at
+    from source
+    where EXECUTION_STATUS = 'SUCCESS'
+      and WAREHOUSE_NAME is not null   -- only compute-bearing statements
+)
+
+select * from transformed

--- a/models/staging/stg_warehouse_metering.sql
+++ b/models/staging/stg_warehouse_metering.sql
@@ -1,0 +1,66 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key='metering_id',
+        on_schema_change='sync_all_columns'
+    )
+}}
+
+-- Authoritative source for compute $: ACCOUNT_USAGE.WAREHOUSE_METERING_HISTORY
+with source as (
+    select *
+    from {{ source('account_usage', 'WAREHOUSE_METERING_HISTORY') }}
+    where START_TIME >= dateadd('day', -{{ var('metering_history_days') }}, current_date())
+    {% if is_incremental() %}
+      and date(END_TIME) >= (
+          select coalesce(max(t.usage_date), '1900-01-01'::date)
+          from {{ this }} as t
+      )
+    {% endif %}
+),
+
+-- Normalize and add cost ($ = credits * cost_per_credit)
+normalized as (
+    select
+        -- keys & time
+        date_trunc('hour', START_TIME)                    as hour_start,
+        date_trunc('hour', END_TIME)                      as hour_end,
+        cast(date_trunc('day', START_TIME) as date)       as usage_date,
+
+        -- warehouse
+        WAREHOUSE_ID,
+        WAREHOUSE_NAME,
+
+        -- credits
+        CREDITS_USED                       as total_credits_used,
+        CREDITS_USED_COMPUTE              as credits_used_compute,
+        CREDITS_USED_CLOUD_SERVICES       as credits_used_cloud_services,
+
+        -- dollars (authoritative)
+        (CREDITS_USED * {{ var('cost_per_credit') }})                as total_cost_usd,
+        (CREDITS_USED_COMPUTE * {{ var('cost_per_credit') }})        as compute_cost_usd,
+        (CREDITS_USED_CLOUD_SERVICES * {{ var('cost_per_credit') }}) as cloud_services_cost_usd,
+
+        -- stable unique key per warehouse-hour
+        concat_ws('|', WAREHOUSE_ID::string, to_char(END_TIME, 'YYYY-MM-DD HH24:MI:SS')) as metering_id,
+
+        current_timestamp() as _loaded_at
+    from source
+)
+
+select
+    hour_start,
+    hour_end,
+    usage_date,
+    WAREHOUSE_ID       as warehouse_id,
+    WAREHOUSE_NAME     as warehouse_name,
+    total_credits_used,
+    credits_used_compute,
+    credits_used_cloud_services,
+    compute_cost_usd,
+    cloud_services_cost_usd,
+    (total_cost_usd - compute_cost_usd) as idle_cost_usd,
+    total_cost_usd,
+    metering_id,
+    _loaded_at
+from normalized

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,0 +1,11 @@
+packages:
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.3.0
+  - name: dbt_expectations
+    package: calogica/dbt_expectations
+    version: 0.10.4
+  - name: dbt_date
+    package: calogica/dbt_date
+    version: 0.10.1
+sha1_hash: 0b23f5fc5714988940cd94ee2302384d6240f8b5


### PR DESCRIPTION
Summary
- Establishes a clean, runnable MVP of the Snowflake FinOps dbt project.
- Anchors all $ to ACCOUNT_USAGE.WAREHOUSE_METERING_HISTORY; per-query $ remains estimates.
- Adds tests (unique, not_null, non-negative) and source freshness.

What changed
- staging: stg_warehouse_metering (incremental; windowed; dev-friendly schema sync)
- staging: stg_query_history (successful, compute-bearing only; windowed incremental)
- intermediate: int_hourly_compute_costs (joins activity→metering; stable keys)
- intermediate: int_query_cost_attribution (prepped; still labeled “estimates”)
- marts: fct_daily_costs (daily compute vs idle)
- models/schema.yml (tests aligned; dbt_expectations arguments nesting)
- models/sources/_snowflake__sources.yml (name=account_usage; freshness)
- README + .gitignore updates

Why it matters
- Demonstrates correct cost authority, idempotent incremental loads, and basic data quality.

Out of scope (next PRs)
- CI (PR build with state:modified+, nightly +fct_daily_costs)
- dbt docs publish & lineage screenshots
- relationships tests, optional model contracts
- chargeback seed for warehouse→team mapping
- clean up unused model-path warnings in dbt_project.yml
