### PR TITLE
feat(v1.2): budget & reliability foundations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2025-09-16
+### Added
+- Dept-aware budget vs actual mart.
+- AU freshness thresholds (warn 48h / error 96h).
+- Schema tests for key models.
+
+### Changed
+- App now reads Live budget table with CSV fallback and shows Budget (MTD) and % Used (MTD) KPIs.

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -203,12 +203,47 @@ def load_models(demo: bool, lookback_days: int):
 
     return fct, dept, fresh
 
-@st.cache_data(show_spinner=False)
-def load_budget() -> Optional[pd.DataFrame]:
-    for p in ("budget_daily.csv", os.path.join("app","budget_daily.csv"), "/mnt/data/budget_daily.csv"):
+@st.cache_data(ttl=60, show_spinner=False)
+def load_budget(demo: bool) -> pd.DataFrame:
+    cp = get_conn_params(); db = cp.get("database", ""); sch = active_schema(demo)
+    if sf is not None and db and sch:
+        try:
+            live = lc(run_query(
+                f"""
+                    select date, department, budget_usd
+                    from {db}.{sch}.budget_daily
+                """,
+                cache_key=f"budget:{db}.{sch}"
+            ))
+            if not live.empty:
+                if "date" in live.columns:
+                    live["date"] = pd.to_datetime(live["date"]).dt.date
+                live = to_float(live, ["budget_usd"])
+                if "department" in live.columns:
+                    live["department"] = live["department"].astype(str).str.strip()
+                required = {"date","department","budget_usd"}
+                if required.issubset(set(live.columns)):
+                    return live[["date","department","budget_usd"]]
+        except Exception:
+            pass
+
+    for p in ("seeds/budget_daily.csv", "budget_daily.csv", os.path.join("app","budget_daily.csv"), "/mnt/data/budget_daily.csv"):
         if os.path.exists(p):
-            b = pd.read_csv(p); b["date"] = pd.to_datetime(b["date"]).dt.date; return b
-    return None
+            try:
+                raw = pd.read_csv(p)
+                cols = {c.lower(): c for c in raw.columns}
+                date_col = cols.get("date"); dept_col = cols.get("department"); usd_col = cols.get("budget_usd")
+                if not (date_col and dept_col and usd_col):
+                    continue
+                out = raw[[date_col, dept_col, usd_col]].copy()
+                out.columns = ["date","department","budget_usd"]
+                out["date"] = pd.to_datetime(out["date"]).dt.date
+                out["department"] = out["department"].astype(str).str.strip()
+                out["budget_usd"] = pd.to_numeric(out["budget_usd"], errors="coerce").fillna(0.0).astype(float)
+                return out
+            except Exception:
+                continue
+    return pd.DataFrame(columns=["date","department","budget_usd"])
 
 @st.cache_data(show_spinner=False)
 def load_current_warehouses():
@@ -260,7 +295,7 @@ def load_pro_hourly_soft(demo: bool, days: int, credit_threshold: float = 0.05) 
     df = to_float(df, ["idle_cost_adj","total_cost","compute_cost","total_hours","active_hours","credits_on_active_hours","total_days","active_days"])
     return df
 
-budget = load_budget()
+budget = pd.DataFrame(columns=["date","department","budget_usd"])
 
 # ---- styles ---------------------------------------------------------------
 st.markdown("""
@@ -308,6 +343,7 @@ with right:
 
 # ---- data -----------------------------------------------------------------
 fct, dept, fresh = load_models(demo_mode, days_shown)
+budget = load_budget(demo_mode)
 today = dt.date.today(); first_day = today.replace(day=1); dim = dim_count(today)
 elapsed = (today - first_day).days + 1
 
@@ -325,10 +361,22 @@ if not fct.empty and "idle_cost" in fct.columns:
 else:
     idle_wasted_last_n = None
 
-monthly_budget = None
-if budget is not None and not budget.empty:
-    month_mask = (budget["date"] >= first_day) & (budget["date"] <= first_day.replace(day=dim))
-    monthly_budget = float(budget.loc[month_mask, "budget_usd"].sum())
+budget_mtd = None
+if not budget.empty and "date" in budget.columns:
+    month_mask = (budget["date"] >= first_day) & (budget["date"] <= today)
+    budget_mtd = float(budget.loc[month_mask, "budget_usd"].sum())
+
+actual_mtd = None
+if not dept.empty and "usage_date" in dept.columns:
+    dept_mtd = dept[(dept["usage_date"] >= first_day) & (dept["usage_date"] <= today)]
+    if not dept_mtd.empty:
+        actual_mtd = float(dept_mtd.get("total_cost_usd", pd.Series([0.0])).sum())
+if actual_mtd is None:
+    actual_mtd = mtd_total
+
+pct_used_mtd = None
+if budget_mtd is not None and budget_mtd > 0:
+    pct_used_mtd = (actual_mtd / budget_mtd) * 100.0
 
 pro_hourly = load_pro_hourly_soft(demo_mode, days_shown) if enable_pro else pd.DataFrame()
 total_idle_est = None
@@ -380,6 +428,18 @@ kpi(row2[0], f"Idle Wasted (last {days_shown} days)",
 kpi(row2[1], "Idle (projected, month)",
     fmt_usd(total_idle_est) if total_idle_est is not None else "—",
     "From Pro hourly model (scaled)" if total_idle_est is not None else "Turn on Pro insights to see this")
+
+row3 = st.columns(2)
+pct_display = "—"
+if pct_used_mtd is not None:
+    try:
+        if not np.isnan(pct_used_mtd):
+            pct_display = f"{pct_used_mtd:.0f}%"
+    except Exception:
+        pct_display = f"{pct_used_mtd:.0f}%"
+
+kpi(row3[0], "Budget (MTD)", fmt_usd(budget_mtd), f"Sum through {today.strftime('%b %d')}")
+kpi(row3[1], "% Used (MTD)", pct_display, "Actual vs departmental budget")
 
 st.divider()
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'snowflake_finops'
-version: '1.1.1'
+version: '1.2.0'
 config-version: 2
 
 profile: 'snowflake_finops'

--- a/models/exposures.yml
+++ b/models/exposures.yml
@@ -5,7 +5,7 @@ exposures:
     type: application
     maturity: medium
     url: "https://mcgrath-dylan.github.io/finops-dbt/base/"
-    description: "Read-only Streamlit app visualizing FinOps marts; Pro surfaces candidates."
+    description: "Read-only Streamlit app visualizing FinOps marts; Pro surfaces candidates. Data recency monitored with 48h warn / 96h error Account Usage freshness thresholds."
     owner:
       name: Dylan McGrath
       email: mcgrath.fintech@gmail.com

--- a/models/marts/finance/fct_budget_vs_actual.sql
+++ b/models/marts/finance/fct_budget_vs_actual.sql
@@ -1,14 +1,29 @@
 {{ config(materialized='table') }}
 
+with daily_actuals as (
+  select
+    f.usage_date,
+    coalesce(nullif(trim(m.department), ''), 'Unassigned') as department,
+    sum(f.compute_cost + f.idle_cost) as actual_cost_usd
+  from {{ ref('fct_daily_costs') }} f
+  left join {{ ref('department_mapping') }} m
+    on upper(f.warehouse_name) = upper(m.warehouse_name)
+  group by 1,2
+),
+budget as (
+  select
+    cast(b.date as date) as usage_date,
+    trim(b.department)    as department,
+    b.budget_usd
+  from {{ ref('budget_daily') }} b
+)
 select
-    b.date as usage_date,
-    b.budget_usd,
-    coalesce(f.total_cost, 0) as actual_cost_usd
-from {{ ref('budget_daily') }} b
-left join (
-    select usage_date, sum(compute_cost + idle_cost) as total_cost
-    from {{ ref('fct_daily_costs') }}
-    group by 1
-) f
-  on f.usage_date = b.date
-order by 1
+  coalesce(a.usage_date, b.usage_date) as usage_date,
+  coalesce(a.department, b.department) as department,
+  coalesce(a.actual_cost_usd, 0)       as actual_cost_usd,
+  coalesce(b.budget_usd, 0)            as budget_usd
+from daily_actuals a
+full outer join budget b
+  on a.usage_date = b.usage_date
+ and a.department = b.department
+order by 1,2

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -59,3 +59,20 @@ models:
         data_type: varchar
       - name: _loaded_at           # cast(current_timestamp() as timestamp_ntz)
         data_type: timestamp_ntz
+  - name: int_hourly_compute_costs
+    columns:
+      - name: cost_hour_key
+        tests:
+          - not_null
+          - unique
+  - name: fct_budget_vs_actual
+    columns:
+      - name: usage_date
+        tests:
+          - not_null
+      - name: department
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [usage_date, department]

--- a/models/sources/_snowflake__sources.yml
+++ b/models/sources/_snowflake__sources.yml
@@ -5,8 +5,10 @@ sources:
     description: Snowflake Account Usage schema
     database: "{{ var('account_usage_database', 'SNOWFLAKE') }}"
     schema: "{{ var('account_usage_schema', 'ACCOUNT_USAGE') }}"
+    loaded_at_field: END_TIME
+    freshness:
+      warn_after: {count: 48, period: hour}
+      error_after: {count: 96, period: hour}
     tables:
       - name: WAREHOUSE_METERING_HISTORY
-        loaded_at_field: END_TIME
       - name: QUERY_HISTORY
-        loaded_at_field: END_TIME

--- a/models/sources/sources_backlog.yml
+++ b/models/sources/sources_backlog.yml
@@ -6,6 +6,8 @@ sources:
   - name: account_usage_backlog
     database: "{{ var('account_usage_database', 'SNOWFLAKE') }}"
     schema: "{{ var('account_usage_schema', 'ACCOUNT_USAGE') }}"
+    config:
+      docs: { show: false }
     tables:
       - name: STORAGE_USAGE
       - name: DATABASE_STORAGE_USAGE_HISTORY

--- a/seeds/schema.yml
+++ b/seeds/schema.yml
@@ -1,0 +1,14 @@
+version: 2
+seeds:
+  - name: budget_daily
+    description: Departmental day-level budget (USD). Demo seed; Live table preferred.
+    columns:
+      - name: date
+        tests: [not_null]
+      - name: department
+        tests: [not_null]
+      - name: budget_usd
+        tests: [not_null]
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: [date, department]


### PR DESCRIPTION
## Summary
- implement department-aware budget vs actual mart with budget seed tests
- configure source freshness thresholds and hide backlog sources from docs
- enhance Streamlit KPIs with live budget loading and month-to-date metrics

## Testing
- `dbt --version`
- `dbt deps`
- `dbt compile --profiles-dir .ci/profiles`
- `dbt parse --profiles-dir .ci/profiles`

## Checklist
- [x] Dept-aware `fct_budget_vs_actual`
- [x] Tests added (`int_hourly_compute_costs`, `fct_budget_vs_actual`, `seeds/budget_daily`)
- [x] AU freshness 48h/96h; backlog hidden from docs
- [x] App KPIs (Budget MTD, % Used) with Live-first loader
- [x] `dbt_project.yml` bumped to 1.2.0
- [x] `CHANGELOG.md` updated
- [x] Attached `target/manifest.json` (and compile logs)

Artifacts: `target/manifest.json`, `logs/dbt.log`


------
https://chatgpt.com/codex/tasks/task_e_68c985306ee48321a9802cdd700feb4d